### PR TITLE
Warn on clippy and usage of rust 2018 idoms.

### DIFF
--- a/src/ex_app_no_layout/create_store.rs
+++ b/src/ex_app_no_layout/create_store.rs
@@ -27,7 +27,6 @@ pub async fn create_store() -> Store<AppNoLayoutState, AppNoLayoutAction> {
   store
 }
 
-
 /// Action.
 #[derive(Clone, Debug)]
 #[non_exhaustive]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,9 @@
 //!   - Redux for state management (fully async, concurrent & parallel).
 //!   - A lolcat implementation w/ a rainbow color-wheel palette.
 
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
+
 // Attach sources.
 
 // Re-export.

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,9 @@
  *   limitations under the License.
  */
 
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
+
 use std::borrow::Cow;
 
 use r3bl_rs_utils::*;
@@ -29,8 +32,6 @@ mod utils;
 // Use things from sources.
 use ex_app_no_layout::*;
 use ex_app_with_layout::*;
-
-
 use reedline::*;
 use utils::*;
 
@@ -68,7 +69,7 @@ async fn run_ex_for_user_selection(selection: Cow<'_, str>) -> CommonResult<()> 
 fn get_user_selection<'a>() -> Cow<'a, str> {
   let mut line_editor = Reedline::create();
   let prompt = DefaultPrompt::default();
-  let mut selection: Cow<str> = Cow::from("");
+  let mut selection: Cow<'_, str> = Cow::from("");
 
   loop {
     let maybe_signal = &line_editor.read_line(&prompt);


### PR DESCRIPTION
It is good practice to use enforce Clippy's suggestions and the usage of 2018 idioms as warnings. Why not errors? During development, it is nice to be able to iterate without caring about Clippy. 

Also removed is the usage of deprecated 2018 hidden lifetimes. It also seems like the external crate export was unused.